### PR TITLE
Looks like GBX might have fixed Ice Age in their latest patch

### DIFF
--- a/Inventory Serial Number Database.json
+++ b/Inventory Serial Number Database.json
@@ -5513,7 +5513,8 @@
       "/Game/PatchDLC/Mayhem2/Gear/Weapon/_Shared/_Unique/Plague/Parts/Part_HW_TOR_Material_Plague.Part_HW_TOR_Material_Plague",
       "/Game/PatchDLC/Geranium/Gear/Weapon/_Unique/Satisfaction/Parts/Part_HW_TOR_Barrel_Satisfaction.Part_HW_TOR_Barrel_Satisfaction",
       "/Game/PatchDLC/Geranium/Gear/Weapon/_Unique/Satisfaction/Parts/Part_HW_TOR_Material_Satisfaction.Part_HW_TOR_Material_Satisfaction",
-      "/Game/PatchDLC/Ixora/Gear/Weapons/_Unique/IceAge/Parts/Part_HW_TOR_Material_IceAge.Part_HW_TOR_Material_IceAge"
+      "/Game/PatchDLC/Ixora/Gear/Weapons/_Unique/IceAge/Parts/Part_HW_TOR_Material_IceAge.Part_HW_TOR_Material_IceAge",
+      "/Game/PatchDLC/Ixora/Gear/Weapons/_Unique/IceAge/Parts/Part_HW_TOR_Barrel_IceAge.Part_HW_TOR_Barrel_IceAge"
     ]
   },
   "BPInvPart_HW_VLA_C": {


### PR DESCRIPTION
An unannounced patch made a small change to the inventory serial DB, might have fixed the Ice Age (which had previously disappeared from inventory on load).